### PR TITLE
Refactor validate method to accept a CDAP Schema JSON object

### DIFF
--- a/src/main/java/co/cask/tracker/entity/DictionaryResult.java
+++ b/src/main/java/co/cask/tracker/entity/DictionaryResult.java
@@ -66,6 +66,10 @@ public class DictionaryResult {
     return description;
   }
 
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
   public String getDatasetsString() {
     return (datasets == null || datasets.isEmpty()) ? "" : Joiner.on(",").join(datasets);
   }
@@ -97,5 +101,4 @@ public class DictionaryResult {
     }
     return result;
   }
-
 }


### PR DESCRIPTION
Refactor validate Api of data dictionary to

* Accept cdap schema json 
* validate more than 1 column in a single call