### PR TITLE
[TRACKER-299] adding default constructor

### DIFF
--- a/src/main/java/co/cask/tracker/AuditLogFlow.java
+++ b/src/main/java/co/cask/tracker/AuditLogFlow.java
@@ -19,6 +19,8 @@ package co.cask.tracker;
 import co.cask.cdap.api.flow.AbstractFlow;
 import co.cask.tracker.config.TrackerAppConfig;
 
+import javax.annotation.Nullable;
+
 /**
  * Defines the flow for reading from TMS and writing to the Audit Log Dataset.
  */
@@ -27,8 +29,8 @@ public class AuditLogFlow extends AbstractFlow {
 
   private final TrackerAppConfig trackerAppConfig;
 
-  public AuditLogFlow(TrackerAppConfig trackerAppConfig) {
-    this.trackerAppConfig = trackerAppConfig;
+  public AuditLogFlow(@Nullable TrackerAppConfig trackerAppConfig) {
+    this.trackerAppConfig = (trackerAppConfig == null) ? new TrackerAppConfig() : trackerAppConfig;
   }
 
   @Override

--- a/src/main/java/co/cask/tracker/TrackerService.java
+++ b/src/main/java/co/cask/tracker/TrackerService.java
@@ -18,6 +18,8 @@ package co.cask.tracker;
 import co.cask.cdap.api.service.AbstractService;
 import co.cask.tracker.config.TrackerAppConfig;
 
+import javax.annotation.Nullable;
+
 /**
  * A service for accessing the Tracker endpoints through a RESTful API.
  */
@@ -25,8 +27,9 @@ public class TrackerService extends AbstractService {
   public static final String SERVICE_NAME = "TrackerService";
   private String zookeeperString;
 
-  public TrackerService(TrackerAppConfig trackerAppConfig) {
-    this.zookeeperString = trackerAppConfig.getAuditLogConfig().getZookeeperString();
+  public TrackerService(@Nullable TrackerAppConfig trackerAppConfig) {
+    this.zookeeperString = (trackerAppConfig == null) ? new TrackerAppConfig().getAuditLogConfig().getZookeeperString()
+                                                      : trackerAppConfig.getAuditLogConfig().getZookeeperString();
   }
 
   public TrackerService() {

--- a/src/main/java/co/cask/tracker/config/TrackerAppConfig.java
+++ b/src/main/java/co/cask/tracker/config/TrackerAppConfig.java
@@ -25,6 +25,10 @@ import co.cask.tracker.TrackerApp;
 public class TrackerAppConfig extends Config {
   private final AuditLogConfig auditLogConfig;
 
+  public TrackerAppConfig() {
+    this.auditLogConfig = new AuditLogConfig();
+  }
+
   public TrackerAppConfig(AuditLogConfig auditLogConfig) {
     this.auditLogConfig = auditLogConfig;
   }


### PR DESCRIPTION
https://issues.cask.co/browse/TRACKER-299
Adding a default constructor and checking for nulls. Allows tracker app to be deployed without specifying a config.
```
cdap (http://xxxxxxxx.local:11015/namespace:test)> create app _Tracker tracker 0.4.0-SNAPSHOT system
Successfully created application
```