### PR TITLE
Update tracker version to 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>co.cask.tracker</groupId>
   <artifactId>tracker</artifactId>
-  <version>0.4.1</version>
+  <version>0.4.0</version>
   <packaging>jar</packaging>
 
   <name>Tracker App</name>


### PR DESCRIPTION
Bring tracker version to 0.4.0, since CDAP 4.1.x UI depends on 0.4.0, and there's no changes in tracker in a hypothetical 0.4.1.