### PR TITLE
Use Java8 to compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <httpcomponents.client.version>4.2.5</httpcomponents.client.version>
     <netty.version>3.6.6.Final</netty.version>
     <maven-compiler.version>3.1</maven-compiler.version>
-    <maven-compiler-source.version>1.7</maven-compiler-source.version>
+    <maven-compiler-source.version>1.8</maven-compiler-source.version>
     <maven-bundle.version>3.0.1</maven-bundle.version>
     <maven-surefire.version>2.14.1</maven-surefire.version>
     <!--TODO Remove twill dependency as per TRACKER-271-->


### PR DESCRIPTION
Build passes locally

```[INFO] --- maven-bundle-plugin:3.0.1:bundle (default) @ tracker ---
[WARNING] Bundle co.cask.tracker:tracker:jar:0.7.0-SNAPSHOT : Export co.cask.tracker,  has 2,  private references [co.cask.cdap.security.spi.authorization, co.cask.cdap.common], 
[WARNING] Bundle co.cask.tracker:tracker:jar:0.7.0-SNAPSHOT : Export co.cask.tracker.entity,  has 4,  private references [co.cask.cdap.proto.id, co.cask.cdap.proto.audit, co.cask.cdap.security.spi.authorization, co.cask.cdap.common], 
[WARNING] Bundle co.cask.tracker:tracker:jar:0.7.0-SNAPSHOT : Export co.cask.tracker.utils,  has 5,  private references [co.cask.cdap.proto.id, co.cask.common.http, co.cask.cdap.security.spi.authorization, co.cask.cdap.common, co.cask.cdap.common.metadata], 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 49.514 s
[INFO] Finished at: 2018-07-19T06:36:54-07:00
[INFO] Final Memory: 74M/750M
[INFO] ------------------------------------------------------------------------```